### PR TITLE
Sort orders by customer

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -6,6 +6,7 @@ All of the models are stored in this module
 import logging
 from datetime import datetime
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import asc, desc
 
 logger = logging.getLogger("flask.app")
 
@@ -205,3 +206,16 @@ class Order(db.Model):
         """Returns all of the orders with customer_id: customer_id """
         cls.logger.info("Processing customer_id query for %s ...", customer_id)
         return cls.query.filter(cls.customer_id == customer_id)
+
+    @classmethod
+    def sort_by(cls, sort, sort_by):
+        """Returns all of the orders sorted by customer_id"""
+        cls.logger.info("Processing all orders query sorted by %s ...", sort)
+        # Defaults sorting is ASC
+        if sort_by is None or (sort_by != 'asc' and sort_by != 'desc'):
+            return cls.query.order_by(asc(sort))
+        else:
+            if sort_by == 'asc':
+                return cls.query.order_by(asc(sort))
+            else:
+                return cls.query.order_by(desc(sort))

--- a/service/routes.py
+++ b/service/routes.py
@@ -160,7 +160,15 @@ def list_orders():
     Returns list of all orders
     """
     app.logger.info("Request for order list")
-    orders = Order.all()
+    
+    params = request.args
+    sort_value = params.get('sort')
+    sortby_value = params.get('sort_by')
+
+    if sort_value is not None:
+        orders = Order.sort_by(sort_value,sortby_value)
+    else:
+        orders = Order.all()
     
     try:
         results = [order.serialize() for order in orders]
@@ -169,7 +177,6 @@ def list_orders():
 
     app.logger.info("Returning %d orders", len(results))
     return make_response(jsonify(results), status.HTTP_200_OK)
-
 
 @app.route("/orders/<int:order_id>", methods=["PUT"])
 def update_orders(order_id):

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -52,7 +52,7 @@ class TestOrderModel(unittest.TestCase):
 ######################################################################
     
     def test_init_order(self):
-        """ Initialize an order and  check if it exists """
+        """ Initialize an order and check if it exists """
         order_items = [Item(product_id=6, quantity=4, price=10)]
         order = Order(customer_id=1, order_items=order_items)
         self.assertTrue(order is not None)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -118,6 +118,11 @@ class TestOrderService(TestCase):
         resp = self.app.get('/orders')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
+    def test_get_sorted_parameters(self):
+        """ Test Get sorted list of orders service by customer id """
+        resp = self.app.get('/orders?sort=customer_id&sort_by=asc')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
     def test_create_order_negative_qty(self):
         """ Create an order with negative quantity """
         order_factory = _get_order_factory_with_items(1)


### PR DESCRIPTION
Closes #40 

Uses "sort" and "sort_by" as keys. Example: sort=customer_id&sort_by=asc.

The functionality not only lets you sort orders by customer, but by any header value. Default sorting is ASC when no sort_by is specified.